### PR TITLE
Fix failing extension loading

### DIFF
--- a/src/TableServiceBundle.php
+++ b/src/TableServiceBundle.php
@@ -24,9 +24,9 @@ class TableServiceBundle extends AbstractBundle
 
     public function loadExtension(array $config, ContainerConfigurator $container, ContainerBuilder $builder): void
     {
-        $container->parameters()->set('azure_table_service.azure_url', $config['azure_url']);
-        $container->parameters()->set('azure_table_service.azure_sas_token', $config['azure_sas_token']);
-        $container->parameters()->set('azure_table_service.azure_table_name', $config['azure_table_name']);
+        $container->parameters()->set('azure_table_service.azure_url', $config['azure_url'] ?? '');
+        $container->parameters()->set('azure_table_service.azure_sas_token', $config['azure_sas_token'] ?? '');
+        $container->parameters()->set('azure_table_service.azure_table_name', $config['azure_table_name'] ?? '');
 
         $container->services()
           ->defaults()


### PR DESCRIPTION
When installing the bundle it fails with:

>  In TableServiceBundle.php line 27:
>  Warning: Undefined array key "azure_url"

During extension loading the $config array may not be populated yet.